### PR TITLE
(NCIOCPL/cgov-digital-platform#2621) Update NCI Connect Spanish Sitewide Search English Template

### DIFF
--- a/elastic/etc/scripts/cgov/search_doc_en.mustache
+++ b/elastic/etc/scripts/cgov/search_doc_en.mustache
@@ -1,80 +1,103 @@
 {     "query": {
-        "bool": {
-          "must": [
-              {"bool": 
-                  {"must":
-                  [
-                  {"exists": {"field": "searchtitle" }},
-                  {"prefix": {"searchurl.raw": "{{my_site}}" } }
-                  ]
-              }},
-            {
-              "bool": {
-                "should": [
-                  {
-                    "match": {
-                      "content": {
-                        "query": "{{my_value}}",
-                        "operator": "and",
-                        "boost": 1
-                      }
-                    }
-                  },
-                  {
-                    "match": {
-                      "searchtitle": {
-                        "query": "{{my_value}}",
-                        "boost": 1
-                      }
-                    }
-                  },
-                  {
-                    "match": {
-                      "searchurl": {
-                        "query": "{{my_value}}",
-                        "boost": 1
-                      }
-                    }
-                  },
-                  {
-                    "match_phrase": {
-                      "content": {
-                        "query": "{{my_value}}",
-                        "boost": 1
-                      }
-                    }
-                  },
-                  {
-                    "bool": {
-                      "should": [
-                        {
-                          "match": {
-                            "metatag.description": {
-                              "query": "{{my_value}}",
-                              "boost": 0.01
-                            }
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ]
-              }
+    "bool": {
+
+    "filter":
+        {"bool": {
+        "should": [
+          {
+            "term": {
+              "metatag.content-language": "en"
             }
-          ],
-          "should": [
-            {
-              "term": {
-                "type": {
-                  "value": "text/html",
-                  "boost": 1
+          },
+          {"bool": {
+              "must_not": {
+                  "exists": {
+                      "field": "metatag.content-language"
+                          }
+                      }
+                  }
+          }
+        ]
+      }}
+    ,
+
+
+      "must": [
+          {"bool": 
+              {"must":
+              [
+              {"exists": {"field": "searchtitle" }},
+              {"prefix": {"searchurl.raw": "{{my_site}}" } }
+              ]
+          }},
+        {
+          "bool": {
+            "should": [
+              {
+                "match": {
+                  "content": {
+                    "query": "{{my_value}}",
+                    "operator": "and",
+                    "boost": 2
+                  }
+                }
+              },
+              {
+                "match": {
+                  "searchtitle": {
+                    "query": "{{my_value}}",
+                    "boost": 2
+                  }
+                }
+              },
+              {
+                "match": {
+                  "searchurl": {
+                    "query": "{{my_value}}",
+                    "boost": 3
+                  }
+                }
+              },
+              {
+                "match_phrase": {
+                  "content": {
+                    "query": "{{my_value}}",
+                    "boost": 3
+                  }
+                }
+              },
+              {
+                "bool": {
+                  "should": [
+                    {
+                      "match": {
+                        "metatag.description": {
+                          "query": "{{my_value}}",
+                          "boost": 0.01
+                        }
+                      }
+                    }
+                  ]
                 }
               }
-            }
-          ]
+            ]
+          }
         }
-      },
-"_source":  [ {{{my_fields}}} ]
-, "size":  "{{my_size}}"
-,"from": "{{my_from}}"
+      ],
+      "should": [
+        {
+          "term": {
+            "type": {
+              "value": "text/html",
+              "boost": 2
+            }
+          }
+        }
+      ]
+    }
   }
+  ,
+  "_source":  [ {{{my_fields}}} ]
+  , "size":  "{{my_size}}"
+  ,"from": "{{my_from}}"
+}

--- a/elastic/etc/scripts/cgov/search_doc_es.mustache
+++ b/elastic/etc/scripts/cgov/search_doc_es.mustache
@@ -1,0 +1,84 @@
+{     "query": {
+    "bool": {
+        "filter": {"term":{"metatag.content-language": "es"}},
+
+      "must": [
+          {"bool": 
+              {"must":
+              [
+              {"exists": {"field": "searchtitle" }},
+              
+              {"prefix": {"searchurl.raw": "{{my_site}}" } }
+              ]
+          }},
+        {
+          "bool": {
+            "should": [
+              {
+                "match": {
+                  "content.es": {
+                    "query": "{{my_value}}",
+                    "operator": "and",
+                    "boost": 1
+                  }
+                }
+              },
+              {
+                "match": {
+                  "searchtitle.es": {
+                    "query": "{{my_value}}",
+                    "boost": 1
+                  }
+                }
+              },
+              {
+                "match": {
+                  "searchurl.es": {
+                    "query": "{{my_value}}",
+                    "boost": 1
+                  }
+                }
+              },
+              {
+                "match_phrase": {
+                  "content.es": {
+                    "query": "{{my_value}}",
+                    "boost": 1
+                  }
+                }
+              },
+              {
+                "bool": {
+                  "should": [
+                    {
+                      "match": {
+                        "metatag.description.es": {
+                          "query": "{{my_value}}",
+                          "boost": 0.01
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "should": [
+        {
+          "term": {
+            "type": {
+              "value": "text/html",
+              "boost": 1
+            }
+          }
+        }
+      ]
+    }
+  },
+"_source":  [ {{{my_fields}}} ]
+, "size":  "{{my_size}}"
+,"from": "{{my_from}}"
+}
+


### PR DESCRIPTION
1. add new search_doc_es search template for DOC Spanish searches.
2. modify existing search_doc_en search template to only search English content.

closes: nciocpl/cgov-digital-platform#2621 